### PR TITLE
Get grid coordinates from a pixel position

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,16 @@ grid.cell_height(grid.cell_width() * 1.2);
 
 Gets current cell width.
 
+### get_cell_from_pixel(position)
+
+Get the position of the cell under a pixel on screen.
+
+Parameters :
+
+- `position` - the position of the pixel to resolve in absolute coordinates, as an object with `top` and `left`properties
+
+Returns an object with properties `x` and `y` i.e. the column and row in the grid.
+
 ### locked(el, val)
 
 Locks/unlocks widget.

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -714,6 +714,17 @@
         return Math.ceil(o.outerWidth() / o.attr('data-gs-width'));
     };
 
+    GridStack.prototype.get_cell_from_pixel = function(position) {
+        var containerPos = this.container.position();
+        var relativeLeft = position.left - containerPos.left;
+        var relativeTop = position.top - containerPos.top;
+
+        var column_width = Math.floor(this.container.width() / this.opts.width);
+        var row_height = this.opts.cell_height + this.opts.vertical_margin;
+
+        return {x: Math.floor(relativeLeft / column_width), y: Math.floor(relativeTop / row_height)};
+    };
+
     scope.GridStackUI = GridStack;
 
     scope.GridStackUI.Utils = Utils;


### PR DESCRIPTION
Hi,
I noticed that there is no direct way to insert a widget from a mouse click or drag&drop of an outside DOM element, as it's needed to resolve the coordinates of the future widget in grid coordinates (row, column).

This PR add a new method get_cell_from_pixel() which will return the row and column corresponding to a pixel coordinates. The input parameter can be directly taken from a drop event from jQueryUI or a mouse event, as in both case they are available as document coordinates.