### PR TITLE
Return new widget on add_widget() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ $('.grid-stack').on('resizestop', function (event, ui) {
 
 ### add_widget(el, x, y, width, height, auto_position)
 
-Creates new widget.
+Creates new widget and returns it.
 
 Parameters:
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -582,6 +582,8 @@
         this.container.append(el);
         this._prepare_element(el);
         this._update_container_height();
+
+        return el;
     };
 
     GridStack.prototype.will_it_fit = function (x, y, width, height, auto_position) {


### PR DESCRIPTION
Hi,

The add_widget() method does not return any value right now. It would be helpful to have the fresh widget returned in order to have a reference available and direct access to its data.