### PR TITLE
Fix method names for access to css rules

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -435,8 +435,8 @@
         if (typeof max_height == 'undefined') {
             max_height = this._styles._max;
             this._styles._max = 0;
-            while (this._styles.rules.length) {
-                this._styles.removeRule(0);
+            while (this._styles.cssRules.length) {
+                this._styles.deleteRule(0);
             }
             this._update_container_height();
         }


### PR DESCRIPTION
Hi,

When dealing with the _sheet_ property of a style element, the plugin is currently using the _rules_ property to access rules. However the attribute does not exist in Firefox nor Safari, they use the attribute _cssRules-.

Notice that IE (9, 10, 11) and Chrome support the cssRules attribute as well as the rules one.
This PR changes the use of _rules_ to _cssRules_ and _removeRule_ to _deleteRule_ (same observation for this function).