### PR TITLE
Improper sorting with respect to nodes of variable widths

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -429,11 +429,12 @@
 
         if (this.opts.auto) {
             var elements = [];
+            var _this = this;
             this.container.children('.' + this.opts.item_class).each(function (index, el) {
                 el = $(el);
                 elements.push({
                     el: el,
-                    i: parseInt(el.attr('data-gs-x')) + parseInt(el.attr('data-gs-y')) * parseInt(el.attr('data-gs-width'))
+                    i: parseInt(el.attr('data-gs-x')) + parseInt(el.attr('data-gs-y')) * _this.opts.width // Use opts.width as weight for Y
                 });
             });
             _.chain(elements).sortBy(function (x) { return x.i; }).each(function (i) {


### PR DESCRIPTION
Cannot sort by the node width otherwise elements which have less width but are supposed to be further down the grid (like bottom right corner for example) end up getting packed and pushed to the top right corner.

By using node.width as a weight for Y, that weight varies per node and causes random undesirable effects.