### PR TITLE
added resize_grid() method, n allowed multiple classes as the 'item_class'.

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -706,13 +706,15 @@
                     node.height = preferredH;
                 }
                 node._dirty = true;
+
                 node = this.grid._prepare_node(node, false);
+                this.grid._fix_collisions(node);
+                
             }, this);
 
-            this.grid._fix_collisions(node);
             this.grid._pack_nodes();
             this.grid._notify(); 
-            
+
             this._update_container_height();
         }
     }; 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -707,11 +707,12 @@
                 }
                 node._dirty = true;
                 node = this.grid._prepare_node(node, false);
-                this.grid._fix_collisions(node);
-
-                this.grid._pack_nodes();
-                this.grid._notify(); 
             }, this);
+
+            this.grid._fix_collisions(node);
+            this.grid._pack_nodes();
+            this.grid._notify(); 
+            
             this._update_container_height();
         }
     }; 


### PR DESCRIPTION
1. Added a resize_grid() method where the nodes will retain their old positions when the grid is resized.
2. And split up the use of the item_class property between using it as a jquery selector, and using it to build some html - via a '_item_class_selector'.
