### PR TITLE
_is_one_column_mode unreliable within five pixels

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -550,7 +550,7 @@
     };
 
     GridStack.prototype._is_one_column_mode = function () {
-        return $(window).width() <= this.opts.min_width;
+        return (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth) <= this.opts.min_width;
     };
 
     GridStack.prototype._prepare_element = function (el) {


### PR DESCRIPTION
$(window).width() is incorrect by about 5 pixels, causing _is_one_column_mode to be incorrect. To test this, go to any gridstack and make the page width 769px. Single column mode via CSS will not kick in, yet elements will not be draggable.