### PR TITLE
Add main property to package.json to enable use via require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gridstack",
   "version": "0.2.3",
   "description": "gridstack.js is a jQuery plugin for widget layout",
+  "main": "dist/gridstack.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/troolee/gridstack.js.git"


### PR DESCRIPTION
This allows use via `require()` as a CommonJS module in Node.js, Browserify, etc.