### PR TITLE
Remove widget: When data doesnt exists try to find the el in nodes of the engine

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -86,6 +86,10 @@
         this.float = true;
     };
 
+    GridStackEngine.prototype.getNodeDataByDOMEl = function(el) {
+        return _.find(this.nodes, function (n) { return el.get(0) === n.el.get(0); });
+    };
+
     GridStackEngine.prototype.commit = function() {
         this._update_counter = 0;
         if (this._update_counter == 0) {
@@ -744,6 +748,10 @@
         detach_node = typeof detach_node === 'undefined' ? true : detach_node;
         el = $(el);
         var node = el.data('_gridstack_node');
+        if(!node) {
+            node = this.grid.getNodeDataByDOMEl(el);
+        }
+
         this.grid.remove_node(node);
         el.removeData('_gridstack_node');
         this._update_container_height();


### PR DESCRIPTION
Hi There,

I'm working on a meteor packaged version of this plugin now everything mostly works fine. 
Except I can't get ```remove_widget``` to work because Meteor is a bit too aggressive with cleaning up the data of the elements.
I've created https://github.com/meteor/meteor/issues/5573 for that but it probably will take forever for the Meteor team to look into it.

The workaround I came up with isn't really damaging or wrong and actually makes the code more robust.
If for some reason the widget you try to remove doesn't have the ```_gridstack_node``` data it tries to look up the node in the nodes array of the engine. You might even consider adding the lookup to all methods. Although the data not existing will probably only ever occur in the ```remove_widget``` function
