### PR TITLE
toggle ui-draggable-handle class with draggable

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -801,9 +801,11 @@
             node.no_move = !(val || false);
             if (node.no_move) {
                 el.draggable('disable');
+                el.removeClass('ui-draggable-handle');
             }
             else {
                 el.draggable('enable');
+                el.addClass('ui-draggable-handle');
             }
         });
         return this;


### PR DESCRIPTION
On touch devices, it's not possible to scroll a page by dragging on an item even when draggable is
disabled due to the **ui-draggable-handle** class which is added to the **grid-stack-item-content**

JQuery-UI Draggable doesn't remove this class when it's disabled, so it prevents touch scrolling the page on the item

```
<div class="grid-stack-item-content ui-draggable-handle">

.ui-draggable-handle {
    -ms-touch-action: none;
    touch-action: none;
}
```