### PR TITLE
new option: drag_constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ $(function () {
 - `static_grid` - makes grid static (default `false`). If true widgets are not movable/resizable. You don't even need jQueryUI draggable/resizable.  A CSS class `grid-stack-static` is also added to the container.
 - `vertical_margin` - vertical gap size (default: `20`)
 - `width` - amount of columns (default: `12`)
+- `drag_constraint` - container to which the drag will be constrained. If dragging outside of it, the move placeholder will be set back to its initial position. Useful if one wants to add behavior when dragging onto other elements of the app.
 
 ## Grid attributes
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -420,7 +420,8 @@
                 handle: (opts.handle_class ? '.' + opts.handle_class : (opts.handle ? opts.handle : '')) || '.grid-stack-item-content',
                 scroll: false,
                 appendTo: 'body'
-            })
+            }),
+            drag_constraint: opts.drag_constraint || undefined
         });
         this.opts.is_nested = is_nested;
 
@@ -634,16 +635,26 @@
             return;
         }
 
-        var cell_width, cell_height;
+        var cell_width, cell_height, grid_height;
+        var dragBox, startPos;
 
         var drag_or_resize = function(event, ui) {
-            var x = Math.round(ui.position.left / cell_width),
-                y = Math.floor((ui.position.top + cell_height / 2) / cell_height),
-                width, height;
+             var x = event.clientX, y = event.clientY;
+            var width, height;
             if (event.type != "drag") {
                 width = Math.round(ui.size.width / cell_width);
                 height = Math.round(ui.size.height / cell_height);
+            } else {
+                if (dragBox && (x < dragBox.left || x > dragBox.right || y < dragBox.top || y > dragBox.bottom)) {
+                    //must move at the end before moving it back to initial position
+                    self.grid.move_node(node, 0, grid_height);
+                    self.grid.move_node(node, startPos.x, startPos.y);
+                    self._update_container_height();
+                    return ;
+                }
             }
+            x = Math.round(ui.position.left / cell_width);
+            y = Math.floor((ui.position.top + cell_height / 2) / cell_height);
 
             if (!self.grid.can_move_node(node, x, y, width, height)) {
                 return;
@@ -666,6 +677,11 @@
                 .attr('data-gs-height', o.attr('data-gs-height'))
                 .show();
             node.el = self.placeholder;
+            startPos = {x: node.x, y: node.y};
+
+            dragBox = self.opts.drag_constraint && $(self.opts.drag_constraint)[0].getBoundingClientRect();
+
+            grid_height = parseInt(self.container.attr('data-gs-current-height'));
 
             el.resizable('option', 'minWidth', Math.round(cell_width * (node.min_width || 1)));
             el.resizable('option', 'minHeight', self.opts.cell_height * (node.min_height || 1));
@@ -688,6 +704,8 @@
                 .removeAttr('style');
             self._update_container_height();
             self._trigger_change_event();
+
+            dragBox = undefined;
 
             self.grid.end_update();
 


### PR DESCRIPTION
This is to ignore the dragging outside of a container. It is not the same as the constraint of jquery draggable, as that one forbids dragging outside of the container. Here, one can drag outside of the container, but the widget position will not be impacted by that dragging, ie the placeholder will go back to its initial position.

This is useful when one wants to add behavior when dragging on another part of the app. For instance, dragging on a menu, in order to move the widget to another dashboard.