### PR TITLE
Allow to specify if widgets are resized when calling setGridWidth

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1417,10 +1417,13 @@
         this.grid.commit();
     };
 
-    GridStack.prototype.setGridWidth = function(gridWidth) {
+    GridStack.prototype.setGridWidth = function(gridWidth,doNotPropagate) {
         this.container.removeClass('grid-stack-' + this.opts.width);
-        this._updateNodeWidths(this.opts.width, gridWidth);
+        if (doNotPropagate !== true) {
+            this._updateNodeWidths(this.opts.width, gridWidth);
+        }
         this.opts.width = gridWidth;
+        this.grid.width = gridWidth;
         this.container.addClass('grid-stack-' + gridWidth);
     };
 


### PR DESCRIPTION
I added a argument 'doNotPropagate' to the setGridWidth. If this argument is explicitly passed as true the inner widgets will not be resized.

And In the setGridWidth method i also updated the GridstackEngine 'width' property in addition to the opts.width. If you do not do it there will be two problems  :
 
-  you will NOT be able to move/resize widgets to the the new space generated if the parent grid has been expanded.
-  you will be able to resize/move a widget beyond the edge of its parent grid the grid's dimensions has been decreased.

Because in the function dragOrResize(_prepareElement) self.grid.width its used to determine if a widget is dragged outside of its parent grid. 