### PR TITLE
Allow negative numbers to be passed to parseHeight function

### DIFF
--- a/dist/gridstack.js
+++ b/dist/gridstack.js
@@ -99,7 +99,7 @@
             var height = val;
             var heightUnit = 'px';
             if (height && _.isString(height)) {
-                var match = height.match(/^([0-9]*\.[0-9]+|[0-9]+)(px|em|rem|vh|vw)?$/);
+                var match = height.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw)?$/);
                 if (!match) {
                     throw new Error('Invalid height');
                 }

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -90,6 +90,8 @@ describe('gridstack utils', function() {
             expect(utils.parseHeight('12.3vh')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vh'}));
             expect(utils.parseHeight('12.3vw')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vw'}));
             expect(utils.parseHeight('12.5')).toEqual(jasmine.objectContaining({height: 12.5, unit: 'px'}));
+            expect(function() { utils.parseHeight('12.5 df'); }).toThrowError('Invalid height');
+
         });
 
         it('should parse negative height value', function() {

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -90,8 +90,18 @@ describe('gridstack utils', function() {
             expect(utils.parseHeight('12.3vh')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vh'}));
             expect(utils.parseHeight('12.3vw')).toEqual(jasmine.objectContaining({height: 12.3, unit: 'vw'}));
             expect(utils.parseHeight('12.5')).toEqual(jasmine.objectContaining({height: 12.5, unit: 'px'}));
-            expect(function() { utils.parseHeight('12.5 df'); }).toThrowError('Invalid height');
         });
 
+        it('should parse negative height value', function() {
+            expect(utils.parseHeight(-12)).toEqual(jasmine.objectContaining({height: -12, unit: 'px'}));
+            expect(utils.parseHeight('-12px')).toEqual(jasmine.objectContaining({height: -12, unit: 'px'}));
+            expect(utils.parseHeight('-12.3px')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'px'}));
+            expect(utils.parseHeight('-12.3em')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'em'}));
+            expect(utils.parseHeight('-12.3rem')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'rem'}));
+            expect(utils.parseHeight('-12.3vh')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'vh'}));
+            expect(utils.parseHeight('-12.3vw')).toEqual(jasmine.objectContaining({height: -12.3, unit: 'vw'}));
+            expect(utils.parseHeight('-12.5')).toEqual(jasmine.objectContaining({height: -12.5, unit: 'px'}));
+            expect(function() { utils.parseHeight('-12.5 df'); }).toThrowError('Invalid height');
+        });
     });
 });

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -99,7 +99,7 @@
             var height = val;
             var heightUnit = 'px';
             if (height && _.isString(height)) {
-                var match = height.match(/^([0-9]*\.[0-9]+|[0-9]+)(px|em|rem|vh|vw)?$/);
+                var match = height.match(/^((-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+)?|-?[0-9]+)(px|em|rem|vh|vw)?$/);
                 if (!match) {
                     throw new Error('Invalid height');
                 }

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -99,7 +99,7 @@
             var height = val;
             var heightUnit = 'px';
             if (height && _.isString(height)) {
-                var match = height.match(/^((-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+)?|-?[0-9]+)(px|em|rem|vh|vw)?$/);
+                var match = height.match(/^(-[0-9]+\.[0-9]+|[0-9]*\.[0-9]+|-[0-9]+|[0-9]+)(px|em|rem|vh|vw)?$/);
                 if (!match) {
                     throw new Error('Invalid height');
                 }


### PR DESCRIPTION
It should be possible to call for example the verticalMargin method with negative numbers.
     
    verticalMargin('-5px')

Instead of bypassing the method

    grid.opts.verticalMarginUnit = 'px';
    grid.opts.verticalMargin = '-5';
    grid._updateStyles();