### PR TITLE
Add a parameter to setGridWidth method to allow not to propagate resi…

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -413,11 +413,12 @@ Toggle the grid animation state.  Toggles the `grid-stack-animate` class.
 
 - `doAnimate` - if `true` the grid will animate.
 
-### setGridWidth(gridWidth)
+### setGridWidth(gridWidth, doNotPropagate)
 
 (Experimental) Modify number of columns in the grid. Will attempt to update existing widgets to conform to new number of columns. Requires `gridstack-extra.css` or `gridstack-extra.min.css`.
 
 - `gridWidth` - Integer between 1 and 12.
+- `doNotPropagate` - if true existing widgets will not be updated.
 
 ### setStatic(staticValue)
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1417,10 +1417,13 @@
         this.grid.commit();
     };
 
-    GridStack.prototype.setGridWidth = function(gridWidth) {
+    GridStack.prototype.setGridWidth = function(gridWidth,doNotPropagate) {
         this.container.removeClass('grid-stack-' + this.opts.width);
-        this._updateNodeWidths(this.opts.width, gridWidth);
+        if (doNotPropagate !== true) {
+            this._updateNodeWidths(this.opts.width, gridWidth);
+        }
         this.opts.width = gridWidth;
+        this.grid.width = gridWidth;
         this.container.addClass('grid-stack-' + gridWidth);
     };
 


### PR DESCRIPTION
Add a parameter to setGridWidth method to allow not to propagate resizing to widgets. 

I also update the this.grid.width property in the setGridWidth function. If you do not do that the GridStackEngine will not be aware of the new width and you will have 2 problems 

- you will not be able to move widget to the newly created space if the grid has been expanded.
- you will be able to to move widget beyond the grid's limit if the grid has been shrinked.