### PR TITLE
Update of initial collisions and dragging onload

### DIFF
--- a/dist/gridstack.js
+++ b/dist/gridstack.js
@@ -156,6 +156,7 @@
         return _.find(this.nodes, function(n) { return el.get(0) === n.el.get(0); });
     };
 
+    var collisions = [];
     GridStackEngine.prototype._fixCollisions = function(node) {
         var self = this;
         this._sortNodes(-1);
@@ -170,8 +171,17 @@
             if (typeof collisionNode == 'undefined') {
                 return;
             }
-            this.moveNode(collisionNode, collisionNode.x, node.y + node.height,
-                collisionNode.width, collisionNode.height, true);
+            if (collisions.indexOf(collisionNode.el.attr('id')) == -1) {
+                var collisionX = parseInt(collisionNode.el.attr('data-gs-x'));
+                var collisionW = parseInt(collisionNode.el.attr('data-gs-width'));
+                var collisionH = parseInt(collisionNode.el.attr('data-gs-height'));
+                collisions.push(collisionNode.el.attr('id'));
+                this.moveNode(collisionNode, collisionX, node.y + node.height,
+                    collisionW, collisionH, true);
+            } else {
+                this.moveNode(collisionNode, collisionNode.x, node.y + node.height,
+                    collisionNode.width, collisionNode.height, true);
+            };
         }
     };
 
@@ -971,6 +981,8 @@
         var cellWidth;
         var cellHeight;
 
+        var firstDrag = true;
+
         var dragOrResize = function(event, ui) {
             var x = Math.round(ui.position.left / cellWidth);
             var y = Math.floor((ui.position.top + cellHeight / 2) / cellHeight);
@@ -1040,6 +1052,13 @@
                 .attr('data-gs-width', o.attr('data-gs-width'))
                 .attr('data-gs-height', o.attr('data-gs-height'))
                 .show();
+            if(firstDrag){
+                node.x = node.el.attr('data-gs-x');
+                node.y = node.el.attr('data-gs-y');
+                node.width = node.el.attr('data-gs-width');
+                node.height = node.el.attr('data-gs-height');
+                firstDrag = false;
+            };
             node.el = self.placeholder;
             node._beforeDragX = node.x;
             node._beforeDragY = node.y;


### PR DESCRIPTION
I discovered that if I have an existing grid stack item in HTML with specified x and y location and I attempt to change the x, y, width, and height onload, then the first drag and first collision of each grid stack item will cause that item to return back to its original x, y, width, and height.

For instance, I could start with this html:
```html
    <div id ="lp1" class="grid-stack-item" data-gs-x="0" data-gs-y="0">
        <div class="grid-stack-item-content">
        </div>
    </div>
```
Then, I could change the x, y, width, and height onload of <body> using this JQuery:
```javascript
    $("#lp1").attr("data-gs-x",3);
    $("#lp1").attr("data-gs-y",1);
    $("#lp1").attr("data-gs-width",4);
    $("#lp1").attr("data-gs-height",4);
```
 to produce this new HTML:
```html
<div id ="lp1" class="grid-stack-item" data-gs-x="3" data-gs-y="1" data-gs-width="4" data-gs-height="4">
```
But the moment that I would start to drag that item (and the moment it first collides with any other item) it would revert back to:
```html
<div id ="lp1" class="grid-stack-item" data-gs-x="0" data-gs-y="0" data-gs-width="1" data-gs-height="1">
```
As a result, I added in the changes to gridstack.js to make it so that the first time any grid stack item is dragged or has a collision it's position and size will be updated with the actual element attributes (x, y, width, and height) rather than the existing node's attributes in the original HTML.
These changes should not affect normal use of gridstack, but they seem to work pretty well for the case where a grid stack item is modified onload.