### PR TITLE
Fire resize event for gridstack node when changing view

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -667,6 +667,8 @@
                     if (!node.noResize && !self.opts.disableResize) {
                         node.el.resizable('enable');
                     }
+
+                    node.el.trigger('resize')
                 });
             }
         };

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -646,6 +646,8 @@
                     if (node.noResize || self.opts.disableResize) {
                         node.el.resizable('disable');
                     }
+
+                    node.el.trigger('resize');
                 });
             } else {
                 if (!oneColumnMode) {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -668,7 +668,7 @@
                         node.el.resizable('enable');
                     }
 
-                    node.el.trigger('resize')
+                    node.el.trigger('resize');
                 });
             }
         };


### PR DESCRIPTION
Add a fire resize event when gridstack pass from desktop to mobile view (one column) and vice versa.

I changed this because when gridstack change his column, every node size is changed but no one event is fire for this.
This can cause problem for content of node that have pixel width and height, and need to be update when his parent change. Like SVG, iframe or other