### PR TITLE
Some fixes when dropping external items.

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -708,7 +708,7 @@
             var onDrag = function(event, ui) {
                 var el = draggingElement;
                 var node = el.data('_gridstack_node');
-                var pos = self.getCellFromPixel(ui.offset, true);
+                var pos = self.getCellFromPixel({left: event.pageX, top: event.pageY}, true);
                 var x = Math.max(0, pos.x);
                 var y = Math.max(0, pos.y);
                 if (!node._added) {

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -715,6 +715,7 @@
                     node._added = true;
 
                     node.el = el;
+                    node.autoPosition = true;
                     node.x = x;
                     node.y = y;
                     self.grid.cleanNodes();
@@ -733,13 +734,12 @@
                     node._beforeDragY = node.y;
 
                     self._updateContainerHeight();
-                } else {
-                    if (!self.grid.canMoveNode(node, x, y)) {
-                        return;
-                    }
-                    self.grid.moveNode(node, x, y);
-                    self._updateContainerHeight();
                 }
+                if (!self.grid.canMoveNode(node, x, y)) {
+                    return;
+                }
+                self.grid.moveNode(node, x, y);
+                self._updateContainerHeight();
             };
 
             $(self.container).droppable({


### PR DESCRIPTION
Old getCellFromPixel call used ui.offset, which has the position of the upper left corner of the dragged item, but we need to track the mouse position.
