### PR TITLE
#460 Grid Height not updated with cellHeight=auto

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1488,8 +1488,8 @@
     };
 
     GridStack.prototype.cellWidth = function() {
-        var o = this.container.children('.' + this.opts.itemClass).first();
-        return Math.ceil(o.outerWidth() / parseInt(o.attr('data-gs-width'), 10));
+        var o = $(this.container);
+        return Math.ceil(o.outerWidth() / o.attr('data-gs-width'));
     };
 
     GridStack.prototype.getCellFromPixel = function(position, useOffset) {


### PR DESCRIPTION
#460 Fixes grid height not updated when added new item using cellHeight = 'auto'