### PR TITLE
Avoid collision check of node with itself. Fixes #586

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -233,6 +233,7 @@
                 var newY = n.y;
                 while (newY >= n._origY) {
                     var collisionNode = _.chain(this.nodes)
+                        .take(i)
                         .find(_.bind(Utils._didCollide, {n: n, newY: newY}))
                         .value();
 


### PR DESCRIPTION
`_packNodes` did not work correctly in floating mode for nodes of height > 1. When trying to move such a node upwards, the repositioned node intersected with its previous position. Fix this by only checking for collisions with preceding nodes instead of all nodes.