### PR TITLE
Workaround for undefined width/height during drag/drop

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -1088,10 +1088,13 @@
                         self.grid.addNode(node);
                         self.placeholder
                             .attr('data-gs-x', x)
-                            .attr('data-gs-y', y)
-                            .attr('data-gs-width', width)
-                            .attr('data-gs-height', height)
-                            .show();
+                            .attr('data-gs-y', y);
+                        if(typeof width !== 'undefined' && typeof height !== 'undefined') {
+                            self.placeholder
+                                .attr('data-gs-width', width)
+                                .attr('data-gs-height', height);
+                        }
+                        self.placeholder.show();
                         self.container.append(self.placeholder);
                         node.el = self.placeholder;
                         node._temporaryRemoved = false;


### PR DESCRIPTION
Hy,

Working with this great JS Library, throw an exception **_placeholder.attr(..).attr(..).attr(..).attr(..) is not a function_**.
During a Debug session, I recognize, that during Drag&Drop the Width and Height of Placeholder is "undefined". 

I tried to enable the width calculation, but this don't work, because Resizing is not initialized. (Correct)

If I look at this part of code, I understand why it don't work, because width is undefined and the attr(...)  function with _undefined_ second parameter returns the value of attribute and not the element.

I don't fully understand, when and why **node._temporaryRemoved** is true AND width is undefined, because I think if this happens, the placeholder would be initialized with wrong width. But everything works like it should in my environment.

Maybe this PR is only a workaround for another issue. I will further check the function.

Regards,

Stefan

PS: I use jQuery 1.x, because your library will work within another software, which force this version. 
It works without problems. 