### PR TITLE
bug fix: keep this._styles._max increasing

### DIFF
--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -947,12 +947,12 @@
         if (typeof maxHeight == 'undefined') {
             maxHeight = this._styles._max;
         }
+        if (this._styles._max !== 0 && maxHeight <= this._styles._max) { // Keep this._styles._max increasing
+            return ;
+        }
         this._initStyles();
         this._updateContainerHeight();
         if (!this.opts.cellHeight) { // The rest will be handled by CSS
-            return ;
-        }
-        if (this._styles._max !== 0 && maxHeight <= this._styles._max) {
             return ;
         }
 


### PR DESCRIPTION
After calling `this._initStyles()`, the condition `this._styles._max !== 0` will never be true. And then a smaller `maxHeight` will be able to assign to `this._styles._max`, and this will cause the missing of some style rules.