### PR TITLE
"trashzone" improvement

### DIFF
--- a/src/gridstack.jQueryUI.js
+++ b/src/gridstack.jQueryUI.js
@@ -77,13 +77,7 @@
 
     JQueryUIGridStackDragDropPlugin.prototype.droppable = function(el, opts) {
         el = $(el);
-        if (opts === 'disable' || opts === 'enable') {
-            el.droppable(opts);
-        } else {
-            el.droppable({
-                accept: opts.accept
-            });
-        }
+        el.droppable(opts);
         return this;
     };
 

--- a/src/gridstack.js
+++ b/src/gridstack.js
@@ -603,6 +603,9 @@
             disableResize: opts.disableResize || false,
             rtl: 'auto',
             removable: false,
+            removableOptions: _.defaults(opts.removableOptions || {}, {
+                accept: '.' + opts.itemClass
+            }),
             removeTimeout: 2000,
             verticalMarginUnit: 'px',
             cellHeightUnit: 'px',
@@ -750,9 +753,7 @@
         if (!self.opts.staticGrid && typeof self.opts.removable === 'string') {
             var trashZone = $(self.opts.removable);
             if (!this.dd.isDroppable(trashZone)) {
-                this.dd.droppable(trashZone, {
-                    accept: '.' + self.opts.itemClass
-                });
+                this.dd.droppable(trashZone, self.opts.removableOptions);
             }
             this.dd
                 .on(trashZone, 'dropover', function(event, ui) {
@@ -761,6 +762,7 @@
                     if (node._grid !== self) {
                         return;
                     }
+                    el.data('inTrashZone', true);
                     self._setupRemovingTimeout(el);
                 })
                 .on(trashZone, 'dropout', function(event, ui) {
@@ -769,6 +771,7 @@
                     if (node._grid !== self) {
                         return;
                     }
+                    el.data('inTrashZone', false);
                     self._clearRemovingTimeout(el);
                 });
         }
@@ -1071,7 +1074,7 @@
             }
 
             if (event.type == 'drag') {
-                if (x < 0 || x >= self.grid.width || y < 0 || (!self.grid.float && y > self.grid.getGridHeight())) {
+                if (el.data('inTrashZone') || x < 0 || x >= self.grid.width || y < 0 || (!self.grid.float && y > self.grid.getGridHeight())) {
                     if (!node._temporaryRemoved) {
                         if (self.opts.removable === true) {
                             self._setupRemovingTimeout(el);


### PR DESCRIPTION
made the "trashzone" configurable through the "removableOptions". All the jq ui options should be supported now

added an "inTrashZone" flag to fix a problem when there is an overlapping between the grid and the "trashzone"

PS I'm not very experienced in github / jq plugins, hope I didn't break anything... if accepted the information about "removableOptions" parameter should be added to the readme doc