### PR TITLE
include linting for npm test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,7 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.registerTask('lint', ['jshint', 'jscs']);
     grunt.registerTask('default', ['sass', 'cssmin', 'jshint', 'jscs', 'copy', 'uglify']);
     grunt.registerTask('e2e-test', ['connect', 'protractor_webdriver', 'protractor']);
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "grunt ; doctoc ./README.md ; doctoc ./doc/README.md ; doctoc ./doc/CHANGES.md",
-    "test": "karma start karma.conf.js"
+    "test": "grunt lint && karma start karma.conf.js"
   },
   "keywords": [
     "gridstack",


### PR DESCRIPTION
To ensure uniform contributions we run the lint command
as part of testing.